### PR TITLE
Refocus demo on Socratic chat

### DIFF
--- a/api/chat.js
+++ b/api/chat.js
@@ -12,7 +12,14 @@ export default async function handler(req, res){
   const p = PERSONAS[personaId];
   if (!p) return res.status(400).json({ error: "Unknown persona" });
 
-  const system = `${p.name} (${p.role}). Stay in character; be concise and educational. Cite canonical sources sparingly in parentheses (e.g., Plato, Laches). Avoid anachronisms.`;
+  const basePrompt = p.chatPrompt || `${p.name} (${p.role}). Stay in character.`;
+  const system = `${basePrompt}
+
+App expectations:
+• Lead with curious, Socratic questioning before giving direct answers.
+• Keep responses concise (≤5 sentences) and invite the user to continue reflecting.
+• Cite canonical sources sparingly in short parentheses drawn from: ${(p.canon || []).join('; ')}.
+• Remain within the persona’s historical voice; avoid anachronisms.`;
   const msgs = [{ role:"system", content: system }, ...history, { role:"user", content:user }];
 
   const r = await fetch("https://api.openai.com/v1/chat/completions", {

--- a/api/personas.js
+++ b/api/personas.js
@@ -8,6 +8,13 @@ export const PERSONAS = {
       "Plato — Apology (method & stance)",
       "Aristotle — Nicomachean Ethics III (courage as mean)"
     ],
+    chatPrompt: `You are Socrates, the Athenian philosopher. Hold a Socratic dialogue with the user.
+
+Principles:
+1. Begin with a probing question or request for clarification before offering explanations.
+2. Use brief, historically grounded answers that reference the listed canon in short parentheses (e.g., Plato, Laches).
+3. Encourage step-by-step reasoning and end with a reflective or follow-up question when possible.
+4. Keep responses concise (no more than 5 sentences) and avoid modern slang or anachronisms.`,
     systemPrompt: `You are Socrates teaching a 1-minute Socratic micro-lesson.
 
 Contract (strict):
@@ -32,6 +39,13 @@ No anachronisms or modern slang. Output JSON ONLY for a single node with keys: {
       "Einstein (1905) mass–energy paper",
       "Einstein & Infeld (1938) The Evolution of Physics"
     ],
+    chatPrompt: `You are Albert Einstein. Teach through curious dialogue.
+
+Guidelines:
+1. Start with a clarifying or leading question before sharing conclusions.
+2. Use plain-language analogies about relativity and energy, citing works from the canon in short parentheses when relevant.
+3. Keep answers within 5 sentences and invite the user to reason alongside you.
+4. Maintain a warm, thoughtful tone without anachronisms.`,
     systemPrompt: `You emulate Einstein for a 1-minute lesson.
 
 Follow the same Contract as Socrates (2 steps total).
@@ -43,6 +57,13 @@ Return strict JSON for a single node.`
     name: "Cleopatra VII",
     role: "Queen of Egypt (statecraft)",
     canon: [ "Plutarch — Life of Antony", "Cassius Dio — Roman History" ],
+    chatPrompt: `You are Cleopatra VII speaking with strategic poise.
+
+Guidelines:
+1. Open with a question that probes the user's situation or assumptions.
+2. Offer concise counsel on leverage, alliances, and diplomacy, citing the canon briefly in parentheses when needed.
+3. Keep responses under 5 sentences and close with a prompt that invites the user to reflect or choose a course.
+4. Remain regal yet pragmatic; avoid caricature or modern slang.`,
     systemPrompt: `You emulate Cleopatra as strategist (no caricature).
 
 Follow the same Contract (choices then terminal).
@@ -54,6 +75,13 @@ Return strict JSON for a single node.`
     name: "Leonardo da Vinci",
     role: "Artist-engineer (perspective)",
     canon: [ "Leonardo — Treatise on Painting", "Alberti — De pictura" ],
+    chatPrompt: `You are Leonardo da Vinci guiding an inquisitive student.
+
+Guidelines:
+1. Lead with a question about perception, technique, or materials before explaining.
+2. Blend artistic and scientific insight, referencing sources from the canon in short parentheses when relevant.
+3. Keep replies under 5 sentences and invite observation or experimentation at the end.
+4. Use Renaissance-era diction without drifting into parody.`,
     systemPrompt: `You emulate Leonardo teaching linear & aerial perspective.
 
 Follow the same Contract (choices then terminal).
@@ -61,28 +89,42 @@ Workshop tone; cite canonical sources.
 Return strict JSON for a single node.`
   },
   galileo: {
-  id: "galileo",
-  name: "Galileo Galilei",
-  role: "Astronomer-physicist (telescopic observations)",
-  canon: [
-    "Galilei — Sidereus Nuncius (1610)",
-    "Galilei — Dialogue Concerning the Two Chief World Systems (1632)"
-  ],
-  systemPrompt: `You emulate Galileo for a 1-minute lesson or chat.
+    id: "galileo",
+    name: "Galileo Galilei",
+    role: "Astronomer-physicist (telescopic observations)",
+    canon: [
+      "Galilei — Sidereus Nuncius (1610)",
+      "Galilei — Dialogue Concerning the Two Chief World Systems (1632)"
+    ],
+    chatPrompt: `You are Galileo Galilei, eager to share telescopic discoveries through questioning.
+
+Guidelines:
+1. Begin with a question that invites the user to observe or compare.
+2. Describe evidence-based reasoning, citing works from the canon in short parentheses when useful.
+3. Stay within 5 sentences and end with a prompt that nudges the user to test or reflect.
+4. Maintain an empirical, wonder-filled tone without anachronisms.`,
+    systemPrompt: `You emulate Galileo for a 1-minute lesson or chat.
 Be clear and observational; favor simple analogies from telescopic observations.
 Cite canonical works sparingly (short labels). Avoid anachronisms.`
-},
-adalovelace: {
-  id: "adalovelace",
-  name: "Ada Lovelace",
-  role: "Mathematician (Analytical Engine)",
-  canon: [
-    "Lovelace — Notes on the Analytical Engine (1843)",
-    "Babbage — On the Analytical Engine (primary context)"
-  ],
-  systemPrompt: `You emulate Ada Lovelace.
+  },
+  adalovelace: {
+    id: "adalovelace",
+    name: "Ada Lovelace",
+    role: "Mathematician (Analytical Engine)",
+    canon: [
+      "Lovelace — Notes on the Analytical Engine (1843)",
+      "Babbage — On the Analytical Engine (primary context)"
+    ],
+    chatPrompt: `You are Ada Lovelace discussing computation as poetic science.
+
+Guidelines:
+1. Lead with a question that clarifies the user's curiosity or challenge.
+2. Explain algorithms, symbolism, or early computing using references from the canon in short parentheses when apt.
+3. Limit replies to 5 sentences and conclude with an invitation to extend the idea.
+4. Sound imaginative yet precise; avoid modern jargon beyond necessity.`,
+    systemPrompt: `You emulate Ada Lovelace.
 Explain computing ideas (algorithms, symbolic manipulation) with historical context.
 Cite canonical works sparingly (short labels). Avoid anachronisms.`
-}
+  }
 
 };

--- a/engine.js
+++ b/engine.js
@@ -1,244 +1,66 @@
-/* -------------------- CONFIG -------------------- */
 const API_BASE = 'https://sota-vert.vercel.app';  // stable Vercel host
-const AI_ENDPOINT   = `${API_BASE}/api/lesson/next`;
 const CHAT_ENDPOINT = `${API_BASE}/api/chat`;
 
-/* -------------------- STATIC LESSONS (fallback) -------------------- */
-const LESSONS = {
-  socrates: {
-    title: "Socrates — What is courage?",
-    nodes: {
-      start: { line: "If courage means ‘no fear,’ fools are bravest. If ‘always fear,’ none are brave. Which sounds right to you?",
-        choices: [
-          { text: "A) No fear", next: "noFear" },
-          { text: "B) Always fear", next: "alwaysFear" },
-          { text: "C) Act despite fear", next: "despite" }
-        ]
-      },
-      noFear:   { line: "Then the reckless drunk charging a cliff is our hero? Perhaps courage needs judgment.", next: "ending" },
-      alwaysFear:{ line: "If we all fear always, who advances? Maybe courage is our relation to the good.", next: "ending" },
-      despite:  { line: "Closer. But ‘despite’ what, and for whose good? Add judgment to action.", next: "ending" },
-      ending: {
-        takeaway: "Courage = knowing fear + judging the good + acting anyway.",
-        sources: [ "Plato, Laches 190e–194e", "Aristotle, Nicomachean Ethics III" ],
-        quiz: [
-          { q: "Which element is essential here?", opts: ["Fearlessness", "Judgment of the good", "Constant fear"], correct: 1 },
-          { q: "‘No fear’ most risks…", opts: ["Cowardice", "Rashness", "Indecision"], correct: 1 }
-        ]
-      }
-    }
-  },
-  einstein: {
-    title: "Einstein — Why E=mc² matters",
-    nodes: {
-      start: { line: "If mass can become energy, what follows?",
-        choices: [
-          { text: "A) Tiny mass holds huge energy", next: "aLot" },
-          { text: "B) Only light has energy", next: "onlyLight" },
-          { text: "C) Mass and energy are unrelated", next: "unrelated" }
-        ]
-      },
-      aLot:      { line: "Yes. c² is enormous—tiny mass → vast energy. Stars (and reactors) run on this.", next: "ending" },
-      onlyLight: { line: "Light has energy, but E=mc² says matter itself embodies energy.", next: "ending" },
-      unrelated: { line: "Relativity unites them: mass is ‘condensed’ energy; they convert under conditions.", next: "ending" },
-      ending: {
-        takeaway: "Mass–energy equivalence: matter stores energy (E=mc²). That’s why stars shine.",
-        sources: [ "Einstein (1905) mass–energy paper", "Einstein & Infeld (1938) The Evolution of Physics" ],
-        quiz: [
-          { q: "Why can tiny mass release huge energy?", opts: ["c² is large", "Mass is small", "Light is fast"], correct: 0 },
-          { q: "E=mc² unites…", opts: ["Force & time", "Mass & energy", "Charge & spin"], correct: 1 }
-        ]
-      }
-    }
-  },
-  cleopatra: {
-    title: "Cleopatra — Leverage beats force",
-    nodes: {
-      start: { line: "You face a stronger rival. Which lever first?",
-        choices: [
-          { text: "A) Information", next: "info" },
-          { text: "B) Loyalty", next: "loyalty" },
-          { text: "C) Spectacle", next: "spectacle" }
-        ]
-      },
-      info:      { line: "Intelligence turns strength predictable. With timing, you trade weakness for leverage.", next: "ending" },
-      loyalty:   { line: "Alliances outlast armies. Bind interests to borrow power you don’t own.", next: "ending" },
-      spectacle: { line: "Display reframes negotiation—when paired with substance.", next: "ending" },
-      ending: {
-        takeaway: "Power is negotiated: combine information, alliances, and timing to bend outcomes.",
-        sources: [ "Plutarch, Life of Antony", "Cassius Dio, Roman History" ],
-        quiz: [
-          { q: "Most durable lever?", opts: ["Spectacle", "Alliances/loyalty", "Secrecy"], correct: 1 },
-          { q: "Info without timing is…", opts: ["Noise", "Force", "Charm"], correct: 0 }
-        ]
-      }
-    }
-  },
-  davinci: {
-    title: "Leonardo — What is perspective?",
-    nodes: {
-      start: { line: "A flat painting can feel deep. What trick makes walls become windows?",
-        choices: [
-          { text: "A) Linear perspective", next: "linear" },
-          { text: "B) Random shading", next: "random" },
-          { text: "C) Bigger skies", next: "skies" }
-        ]
-      },
-      linear: { line: "Parallel lines meet at a vanishing point; scale shrinks with distance. Space appears.", next: "ending" },
-      random: { line: "Shading helps, but without geometry the illusion collapses.", next: "ending" },
-      skies:  { line: "Composition matters, but depth needs structure—lines, scale, atmosphere.", next: "ending" },
-      ending: {
-        takeaway: "Perspective = geometry + light: vanishing points, scaling, and aerial falloff create depth.",
-        sources: [ "Leonardo, Treatise on Painting", "Alberti (1435), De pictura" ],
-        quiz: [
-          { q: "Defines linear perspective?", opts: ["Random shadows", "Vanishing point geometry", "Wide canvases"], correct: 1 },
-          { q: "Distant objects appear…", opts: ["Larger & sharper", "Smaller & hazier", "Same size"], correct: 1 }
-        ]
-      }
-    }
-  }
-};
-
-/* -------------------- ENGINES -------------------- */
-class StaticScriptEngine {
-  constructor(script) { this.script = script; }
-  async next(req) {
-    const state = req.state || { personaId: req.personaId, history: [] };
-    const nodes = this.script.nodes;
-    const nodeId = !state.history.length ? 'start' : (req.userChoiceId || 'ending');
-    const node = nodes[nodeId] || nodes['ending'];
-    state.history.push({ nodeId, choiceId: req.userChoiceText || null });
-    return { node, state };
-  }
-}
-class OpenAICharacterEngine {
-  constructor(endpoint) { this.endpoint = endpoint; }
-  async next(req) {
-    const r = await fetch(this.endpoint, {
-      method: 'POST', headers: { 'Content-Type':'application/json' }, body: JSON.stringify(req)
-    });
-    if (!r.ok) throw new Error(await r.text());
-    return r.json();
-  }
-}
-
-/* -------------------- LESSON UI -------------------- */
-const el = id => document.getElementById(id);
-const picker = el('lessonPicker');
-const enginePicker = el('enginePicker');
-const startBtn = el('startBtn');
-const restartBtn = el('restartBtn');
-const replayBtn = el('replayBtn');
-const scene = el('scene');
-const line = el('line');
-const choices = el('choices');
-const takeaway = el('takeaway');
-const sources = el('sources');
-const quiz = el('quiz');
-const cta = el('cta');
-const email = el('email');
-const copyBtn = el('copyResults');
-const copied = el('copied');
-
-let curKey = 'socrates';
-let curEngineMode = 'script';
-let state = undefined;
-let transcript = [], answers = [], score = 0;
-
-function tts(text){ try { const u = new SpeechSynthesisUtterance(text); u.rate=1.02; speechSynthesis.cancel(); speechSynthesis.speak(u); } catch(e){} }
-
-function renderNode(node){
-  choices.innerHTML=''; takeaway.innerHTML=''; sources.innerHTML=''; quiz.innerHTML=''; cta.style.display='none';
-
-  if (node.line){ line.textContent = node.line; tts(node.line); transcript.push('> '+node.line); replayBtn.disabled=false; }
-  else { line.textContent=''; replayBtn.disabled=true; }
-
-  if (node.choices){
-    node.choices.forEach(ch=>{
-      const b=document.createElement('button');
-      b.textContent = ch.text;
-      // accept id from AI, or next from script
-      b.onclick = ()=> advance(ch.id ?? ch.next ?? null, ch.text);
-      choices.appendChild(b);
-    });
-  } else if (node.takeaway){
-    line.textContent = 'Takeaway'; tts(node.takeaway);
-    takeaway.innerHTML = `<div class="pill">Takeaway</div><div class="mt8">${node.takeaway}</div>`;
-    sources.innerHTML = `<div class="pill">Sources</div><ul class="mt8">` + (node.sources||[]).map(s=>`<li class="small">${s}</li>`).join('') + `</ul>`;
-    score = 0; quiz.innerHTML = `<div class="pill">Quick check (2)</div>`;
-    (node.quiz||[]).forEach((q,i)=>{
-      const wrap = document.createElement('div'); wrap.className='mt12'; wrap.innerHTML = `<div>${i+1}. ${q.q}</div>`;
-      q.opts.forEach((opt,idx)=>{
-        const btn=document.createElement('button'); btn.className='secondary mt8'; btn.textContent=opt;
-        btn.onclick=()=>{ btn.disabled=true; if(idx===q.correct){ score++; btn.style.borderColor='#2b67f6'; btn.style.color='#cfe0ff'; } else { btn.style.opacity='.7'; } };
-        wrap.appendChild(document.createElement('br')); wrap.appendChild(btn);
-      }); quiz.appendChild(wrap);
-    });
-    cta.style.display='block';
-  }
-}
-
-async function advance(userChoiceId=null, userChoiceText=null){
-  const goal = (curKey==='socrates') ? 'define courage via contrasts'
-             : (curKey==='einstein') ? 'explain mass-energy equivalence'
-             : (curKey==='cleopatra') ? 'show leverage vs force'
-             : 'explain linear & aerial perspective';
-
-  const req = { personaId: curKey, goal, state, userChoiceId, userChoiceText };
-  try{
-    const engineImpl = (curEngineMode==='ai') ? new OpenAICharacterEngine(AI_ENDPOINT)
-                                              : new StaticScriptEngine(LESSONS[curKey]);
-    const resp = await engineImpl.next(req);
-    state = resp.state; scene.textContent = LESSONS[curKey].title; renderNode(resp.node);
-    if (userChoiceText){ answers.push(userChoiceText); transcript.push(userChoiceText); }
-  }catch(e){
-    // graceful fallback to script start
-    curEngineMode = 'script';
-    enginePicker.value = 'script';
-    state = undefined; transcript=[]; answers=[]; score=0;
-    const resp = await new StaticScriptEngine(LESSONS[curKey]).next({ personaId: curKey, state });
-    scene.textContent = LESSONS[curKey].title + ' (script fallback)'; renderNode(resp.node);
-  }
-}
-
-replayBtn.onclick = ()=>{ const last = transcript.slice().reverse().find(t=>t.startsWith('> ')); if(last) tts(last.slice(2)); };
-startBtn.onclick  = ()=>{ curKey=picker.value; curEngineMode=enginePicker.value; state=undefined; transcript=[]; answers=[]; score=0; advance(); };
-restartBtn.onclick= ()=>{ state=undefined; transcript=[]; answers=[]; score=0; advance(); };
-copyBtn.onclick   = ()=>{ const payload = [`Figure: ${LESSONS[curKey].title}`, `Engine: ${enginePicker.value}`, `Choices: ${answers.join(' | ')||'(none)'}`, `Score: ${score} / 2`, `Email: ${email.value||'(none)'}`, `Transcript:\n${transcript.join('\n')}`].join('\n'); navigator.clipboard.writeText(payload).then(()=>{ copied.style.display='block'; setTimeout(()=>copied.style.display='none',1500); }); };
-
-/* -------------------- CHAT UI -------------------- */
-const tabLessons = document.getElementById('tabLessons'), tabChat = document.getElementById('tabChat');
-const lessonCard = document.getElementById('lessonCard'), chatCard = document.getElementById('chatCard');
-const chatWho = document.getElementById('chatWho'), chatLog = document.getElementById('chatLog');
-const chatInput = document.getElementById('chatInput'), sendChat = document.getElementById('sendChat'), newChat = document.getElementById('newChat');
+const chatWho   = document.getElementById('chatWho');
+const chatLog   = document.getElementById('chatLog');
+const chatInput = document.getElementById('chatInput');
+const sendChat  = document.getElementById('sendChat');
+const newChat   = document.getElementById('newChat');
 
 let chatHistory = [];
-function showLessons(){ tabLessons.classList.add('active'); tabChat.classList.remove('active'); lessonCard.style.display='block'; chatCard.style.display='none'; }
-function showChat(){ tabChat.classList.add('active'); tabLessons.classList.remove('active'); lessonCard.style.display='none'; chatCard.style.display='block'; }
-tabLessons.onclick = showLessons; tabChat.onclick = showChat;
 
-function addMsg(text, me=false){ const d=document.createElement('div'); d.className='msg '+(me?'me':'them'); d.textContent=text; chatLog.appendChild(d); chatLog.scrollTop = chatLog.scrollHeight; }
-async function sendChatMsg(){
-  const q = (chatInput.value||'').trim(); if(!q) return; chatInput.value=''; addMsg(q,true);
-  try{
-    const r = await fetch(CHAT_ENDPOINT,{ method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({ personaId: chatWho.value, history: chatHistory, user: q }) });
-    const j = await r.json(); chatHistory = j.history || chatHistory; addMsg(j.reply || '[no reply]');
-  }catch(err){ addMsg('[error contacting server]'); }
+function personaName(id){
+  const option = Array.from(chatWho.options).find(opt => opt.value === id);
+  return option ? option.text : 'the selected figure';
 }
-sendChat.onclick = sendChatMsg; chatInput.onkeydown = e=>{ if(e.key==='Enter') sendChatMsg(); };
-newChat.onclick = ()=>{ chatHistory=[]; chatLog.innerHTML=''; addMsg(`You are now speaking with ${chatWho.options[chatWho.selectedIndex].text}.`); };
 
-// Card selection: clicking a card picks the persona & shows a system line
-document.querySelectorAll('.cardBtn').forEach(btn=>{
-  btn.onclick = ()=>{
+function addMsg(text, me=false){
+  const d = document.createElement('div');
+  d.className = 'msg ' + (me ? 'me' : 'them');
+  d.textContent = text;
+  chatLog.appendChild(d);
+  chatLog.scrollTop = chatLog.scrollHeight;
+}
+
+function resetChat(id = chatWho.value){
+  chatHistory = [];
+  chatLog.innerHTML = '';
+  const name = personaName(id);
+  addMsg(`You are now speaking with ${name}. Expect probing questions before answers.`);
+}
+
+async function sendChatMsg(){
+  const q = (chatInput.value || '').trim();
+  if(!q) return;
+  chatInput.value = '';
+  addMsg(q, true);
+
+  try{
+    const r = await fetch(CHAT_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type':'application/json' },
+      body: JSON.stringify({ personaId: chatWho.value, history: chatHistory, user: q })
+    });
+    const j = await r.json();
+    chatHistory = j.history || chatHistory;
+    addMsg(j.reply || '[no reply]');
+  }catch(err){
+    addMsg('[error contacting server]');
+  }
+}
+
+sendChat.onclick = sendChatMsg;
+chatInput.onkeydown = e => { if(e.key === 'Enter') sendChatMsg(); };
+newChat.onclick = () => resetChat();
+chatWho.onchange = () => resetChat(chatWho.value);
+
+document.querySelectorAll('.cardBtn').forEach(btn => {
+  btn.onclick = () => {
     const id = btn.dataset.id;
-    const name = btn.querySelector('div').textContent.trim();
-    chatWho.value = id;          // set dropdown too
-    chatHistory = [];            // new conversation per persona
-    chatLog.innerHTML = '';
-    addMsg(`You are now speaking with ${name}.`, false);
+    chatWho.value = id;
+    resetChat(id);
   };
 });
 
-/* default view */
-showLessons();
+// default
+resetChat();

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>School of the Ancients — 1-Minute Micro-Lessons + Chat</title>
+<title>School of the Ancients — Socratic Chat Prototype</title>
 <style>
   body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin:0; background:#0f0f14; color:#f5f7fb; }
   header { padding:16px 20px; border-bottom:1px solid #232536; display:flex; gap:12px; align-items:center; flex-wrap:wrap;}
@@ -16,6 +16,10 @@
   button.secondary { background:#232536; border:1px solid #2a2d42; color:#cdd3e1; }
   button.ghost { background:transparent; border:1px solid #2a2d42; color:#cdd3e1; }
   button:disabled { opacity:.5; cursor:not-allowed; }
+  .cardBtn { background:#101522; border:1px solid #2a2d42; border-radius:14px; padding:0; color:#f5f7fb; width:140px; }
+  .cardBtn:hover { border-color:#2b67f6; }
+  .cardBtn img { border-radius:12px 12px 0 0; width:140px; height:200px; object-fit:cover; display:block; }
+  .cardBtn .small { display:block; padding:8px; text-align:center; }
   select, input[type="text"] { background:#0f1320; color:#e8ecf7; border:1px solid #2a2d42; border-radius:10px; padding:10px; }
   .dim { color:#aab2c8; font-size:13px; }
   .choices button { flex:1 1 180px; }
@@ -28,10 +32,9 @@
   .msg { padding:10px 12px; border-radius:12px; margin:8px 0; max-width:80% }
   .me { background:#1b243a; margin-left:auto }
   .them { background:#101522; border:1px solid #2a2d42 }
-  /* tabs */
-  .tabs { display:flex; gap:8px; margin:16px 0; }
-  .tabs button { padding:8px 12px; border-radius:999px; }
-  .tabs .active { background:#2b67f6; border:0; color:white; }
+  .hero { margin:16px 0 24px; }
+  .hero h2 { margin:0; font-size:22px; }
+  .hero p { margin:6px 0 0; color:#aab2c8; max-width:620px; }
   .home-link {
   color: inherit;
   text-decoration: none;
@@ -47,66 +50,18 @@
 <header>
   <h1><a href="https://schooloftheancients.com/" class="home-link">School of the Ancients</a></h1>
   <span class="tag">Alpha Demo</span>
-  <span class="tag">1-minute Socratic lessons + Chat</span>
+  <span class="tag">Socratic dialogue playground</span>
 </header>
 
 
 <main>
-  <div class="tabs">
-    <button id="tabLessons" class="active">Lessons</button>
-    <button id="tabChat" class="ghost">Chat</button>
-  </div>
-
-  <!-- LESSONS CARD -->
-  <div id="lessonCard" class="card">
-    <div class="row" style="justify-content:space-between">
-      <div class="row">
-        <div>
-          <div class="dim small">Pick a figure</div>
-          <select id="lessonPicker">
-            <option value="socrates">Socrates — What is courage?</option>
-            <option value="einstein">Einstein — Why E=mc² matters</option>
-            <option value="cleopatra">Cleopatra — Leverage beats force</option>
-            <option value="davinci">Leonardo — What is perspective?</option>
-          </select>
-        </div>
-        <div>
-          <div class="dim small">Engine</div>
-          <select id="enginePicker">
-            <option value="script">Script (offline)</option>
-            <option value="ai">AI (beta)</option>
-          </select>
-        </div>
-      </div>
-      <div class="row">
-        <button id="startBtn">Start 1-minute demo</button>
-        <button id="restartBtn" class="ghost">Restart</button>
-        <button id="replayBtn" class="secondary" disabled>Replay line (🔊)</button>
-      </div>
-    </div>
-
-    <div id="stage" class="mt16">
-      <div id="scene" class="dim small">Tip: Click a choice to continue. Audio uses your device’s voice.</div>
-      <div id="line" class="mt12" style="font-size:20px; line-height:1.4;"></div>
-      <div id="choices" class="choices row mt12"></div>
-
-      <div id="takeaway" class="mt16"></div>
-      <div id="sources" class="mt12 small"></div>
-      <div id="quiz" class="mt16"></div>
-
-      <div id="cta" class="footer mt16" style="display:none;">
-        <div class="dim small">Like this? Join the CU beta:</div>
-        <div class="row mt8">
-          <input id="email" type="text" placeholder="email@colorado.edu" />
-          <button id="copyResults" class="secondary">Copy results</button>
-        </div>
-        <div id="copied" class="small mt8" style="display:none;">Results copied. Paste into an email/DM to join.</div>
-      </div>
-    </div>
-  </div>
+  <section class="hero">
+    <h2>Have a Socratic conversation with history&rsquo;s greats.</h2>
+    <p>Select a figure, ask anything, and they will guide you with questions and references &mdash; no scripted lesson flow.</p>
+  </section>
 
   <!-- CHAT CARD -->
-  <div id="chatCard" class="card" style="display:none;">
+  <div id="chatCard" class="card">
     <div class="row" style="justify-content:space-between">
       <div class="row">
         <div>
@@ -122,44 +77,43 @@
         </div>
       </div>
       <div class="row">
-        <button id="newChat" class="ghost">New chat</button>
+        <button id="newChat" class="ghost">Start fresh</button>
       </div>
     </div>
 
     <!-- Character cards grid -->
-<div id="cardGrid" class="row" style="gap:16px; flex-wrap:wrap; margin-bottom:8px">
-  <button class="cardBtn" data-id="einstein">
-    <img src="./img/einstein.jpg" alt="Albert Einstein" style="width:140px;height:200px;object-fit:cover;border-radius:12px;display:block">
-    <div class="small" style="text-align:center;margin-top:6px">Albert Einstein</div>
-  </button>
-  <button class="cardBtn" data-id="galileo">
-    <img src="./img/galileo.jpg" alt="Galileo Galilei" style="width:140px;height:200px;object-fit:cover;border-radius:12px;display:block">
-    <div class="small" style="text-align:center;margin-top:6px">Galileo Galilei</div>
-  </button>
-  <button class="cardBtn" data-id="davinci">
-    <img src="./img/davinci.jpg" alt="Leonardo da Vinci" style="width:140px;height:200px;object-fit:cover;border-radius:12px;display:block">
-    <div class="small" style="text-align:center;margin-top:6px">Leonardo Da Vinci</div>
-  </button>
-  <button class="cardBtn" data-id="adalovelace">
-    <img src="./img/adalovelace.jpg" alt="Ada Lovelace" style="width:140px;height:200px;object-fit:cover;border-radius:12px;display:block">
-    <div class="small" style="text-align:center;margin-top:6px">Ada Lovelace</div>
-  </button>
-  <button class="cardBtn" data-id="cleopatra">
-    <img src="./img/cleopatra.jpg" alt="Cleopatra" style="width:140px;height:200px;object-fit:cover;border-radius:12px;display:block">
-    <div class="small" style="text-align:center;margin-top:6px">Cleopatra</div>
-  </button>
-</div>
-
+    <div id="cardGrid" class="row" style="gap:16px; flex-wrap:wrap; margin:12px 0">
+      <button class="cardBtn" data-id="einstein">
+        <img src="./img/einstein.jpg" alt="Albert Einstein">
+        <div class="small">Albert Einstein</div>
+      </button>
+      <button class="cardBtn" data-id="galileo">
+        <img src="./img/galileo.jpg" alt="Galileo Galilei">
+        <div class="small">Galileo Galilei</div>
+      </button>
+      <button class="cardBtn" data-id="davinci">
+        <img src="./img/davinci.jpg" alt="Leonardo da Vinci">
+        <div class="small">Leonardo Da Vinci</div>
+      </button>
+      <button class="cardBtn" data-id="adalovelace">
+        <img src="./img/adalovelace.jpg" alt="Ada Lovelace">
+        <div class="small">Ada Lovelace</div>
+      </button>
+      <button class="cardBtn" data-id="cleopatra">
+        <img src="./img/cleopatra.jpg" alt="Cleopatra">
+        <div class="small">Cleopatra</div>
+      </button>
+    </div>
 
     <div id="chatLog"></div>
     <div class="row" style="margin-top:8px">
       <input id="chatInput" placeholder="Ask a question…" style="flex:1" />
       <button id="sendChat">Send</button>
     </div>
-    <div class="small" style="margin-top:8px">AI via Vercel API • replies try to cite canonical sources sparingly</div>
+    <div class="small" style="margin-top:8px">AI via Vercel API • replies use Socratic Q&amp;A with canonical citations when relevant</div>
   </div>
 
-  <p class="dim small mt12">Validation-first: explicit takeaway, sources, and 2 checks. Toggle AI to test character emulation. Chat lane for open-ended convo.</p>
+  <p class="dim small mt12">Prototype goal: recreate the original chat-first demo. Socratic guidance now comes from the prompt instead of a scripted lesson tree.</p>
 </main>
 
 <script src="./engine.js"></script>


### PR DESCRIPTION
## Summary
- remove the lesson tab and present the chat interface as the primary experience with updated hero copy and persona cards
- simplify the front-end script so it only manages chat sessions, persona selection, and message handling
- add Socratic dialogue guidance to each persona prompt and ensure the chat API feeds the new instructions to the model

## Testing
- No automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d891087b50832fa0e1a36a0c70a969