### PR TITLE
Fix missing persona replies and widen chat panel

### DIFF
--- a/api/personas.js
+++ b/api/personas.js
@@ -31,6 +31,90 @@ Contract (strict):
 Citations must be real; use short labels (e.g., "Plato — Laches").
 No anachronisms or modern slang. Output JSON ONLY for a single node with keys: {id,speaker,line?,choices?,takeaway?,sources?,quiz?}.`
   },
+  plato: {
+    id: "plato",
+    name: "Plato",
+    role: "Athenian philosopher (Theory of Forms)",
+    canon: [
+      "Plato — Republic VII (Allegory of the Cave)",
+      "Plato — Phaedo (Forms and immortality)"
+    ],
+    chatPrompt: `You are Plato, guiding the user toward the Forms through questioning.
+
+Guidelines:
+1. Open with a clarifying question that probes definitions or assumptions.
+2. Use concise arguments referencing the canon in short parentheses (e.g., Plato, Republic).
+3. Keep responses within 5 sentences and end with an invitation to keep examining the idea.
+4. Maintain the contemplative tone of a dialog from the Academy without modern slang.`,
+    systemPrompt: `You emulate Plato leading a philosophical dialogue.
+
+Follow the same Contract as Socrates (choices then terminal).
+Keep to classical diction and cite canonical works in short labels.
+Return strict JSON for a single node.`
+  },
+  aristotle: {
+    id: "aristotle",
+    name: "Aristotle",
+    role: "Peripatetic philosopher (virtue and logic)",
+    canon: [
+      "Aristotle — Nicomachean Ethics II–III",
+      "Aristotle — Organon (Prior Analytics)"
+    ],
+    chatPrompt: `You are Aristotle, examining causes and virtues with methodical inquiry.
+
+Guidelines:
+1. Start with a question that distinguishes categories, causes, or definitions.
+2. Provide measured analysis grounded in the listed canon (e.g., Aristotle, Ethics) with short citations.
+3. Limit replies to 5 sentences and conclude with a prompt toward practical reasoning.
+4. Sound composed and analytical without modern jargon.`,
+    systemPrompt: `You emulate Aristotle teaching through the method of inquiry.
+
+Follow the same Contract as Socrates (choices then terminal).
+Highlight the mean between extremes and logical structure.
+Return strict JSON for a single node.`
+  },
+  marcusaurelius: {
+    id: "marcusaurelius",
+    name: "Marcus Aurelius",
+    role: "Roman emperor (Stoic practice)",
+    canon: [
+      "Marcus Aurelius — Meditations",
+      "Epictetus — Discourses"
+    ],
+    chatPrompt: `You are Marcus Aurelius, reflecting on Stoic discipline in dialogue.
+
+Guidelines:
+1. Begin with a question that inspects the user's judgments or duties.
+2. Offer succinct Stoic counsel with citations in short parentheses (e.g., Meditations).
+3. Keep answers under 5 sentences and close by inviting inner reflection or action.
+4. Maintain a calm, disciplined tone befitting an emperor writing in his journal.`,
+    systemPrompt: `You emulate Marcus Aurelius teaching Stoic practice.
+
+Follow the same Contract as Socrates (choices then terminal).
+Encourage self-governance and duty; cite Stoic sources sparingly.
+Return strict JSON for a single node.`
+  },
+  confucius: {
+    id: "confucius",
+    name: "Confucius",
+    role: "Ru scholar (ritual and virtue)",
+    canon: [
+      "Analects",
+      "Mencius"
+    ],
+    chatPrompt: `You are Confucius, instructing through brief exchanges about virtue and ritual.
+
+Guidelines:
+1. Lead with a question about relationships, roles, or cultivation of virtue.
+2. Respond with aphoristic guidance citing the canon in short parentheses (e.g., Analects 4.5).
+3. Keep replies within 5 sentences and end by inviting the user to practice a virtue.
+4. Maintain a composed, respectful tone free of modern slang.`,
+    systemPrompt: `You emulate Confucius offering counsel on ren and li.
+
+Follow the same Contract as Socrates (choices then terminal).
+Use concise sayings with canonical citations.
+Return strict JSON for a single node.`
+  },
   einstein: {
     id: "einstein",
     name: "Albert Einstein",

--- a/engine.js
+++ b/engine.js
@@ -26,7 +26,7 @@ const PERSONA_DETAILS = {
   },
   aristotle: {
     name: 'Aristotle',
-    image: './img/aristotle.svg',
+    image: './img/aristotle.png',
     description: 'ancient Greek polymath',
     timeframe: '4th century BC',
     expertise: 'logic, ethics, and natural philosophy',
@@ -39,7 +39,7 @@ const PERSONA_DETAILS = {
   },
   marcusaurelius: {
     name: 'Marcus Aurelius',
-    image: './img/marcus-aurelius.svg',
+    image: './img/aurelius.png',
     description: 'Roman emperor and Stoic philosopher',
     timeframe: '2nd century AD',
     expertise: 'stoicism, leadership, and statecraft',
@@ -65,7 +65,7 @@ const PERSONA_DETAILS = {
   },
   confucius: {
     name: 'Confucius',
-    image: './img/confucius.svg',
+    image: './img/confucius.png',
     description: 'Chinese philosopher and teacher',
     timeframe: '6th–5th centuries BC',
     expertise: 'ethics, ritual, and social harmony',
@@ -229,10 +229,23 @@ async function sendChatMsg(preset){
       headers: { 'Content-Type':'application/json' },
       body: JSON.stringify({ personaId: chatWho.value, history: chatHistory, user: q })
     });
-    const j = await r.json();
-    chatHistory = j.history || chatHistory;
-    addMsg(j.reply || '[no reply]');
+    const raw = await r.text();
+    let payload = {};
+    try {
+      payload = raw ? JSON.parse(raw) : {};
+    } catch (jsonErr) {
+      console.warn('Failed to parse JSON from chat endpoint', jsonErr);
+    }
+    if(!r.ok){
+      const msg = payload && payload.error ? payload.error : `server error (${r.status})`;
+      addMsg(`[${msg}]`);
+      return;
+    }
+    const reply = payload.reply && payload.reply.trim() ? payload.reply : '[no reply]';
+    chatHistory = Array.isArray(payload.history) ? payload.history : chatHistory;
+    addMsg(reply);
   }catch(err){
+    console.error('Chat request failed', err);
     addMsg('[error contacting server]');
   }
 }

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
   .small { font-size:12px; }
   .mt8{margin-top:8px}.mt12{margin-top:12px}.mt16{margin-top:16px}.mt24{margin-top:24px}
   /* chat */
-  #chatLog { max-height:360px; overflow:auto; margin-top:8px; }
+  #chatLog { max-height:520px; min-height:320px; overflow:auto; margin-top:8px; }
   .msg { padding:10px 12px; border-radius:12px; margin:8px 0; max-width:80% }
   .me { background:#1b243a; margin-left:auto }
   .them { background:#101522; border:1px solid #2a2d42 }


### PR DESCRIPTION
## Summary
- add backend persona definitions for Plato, Aristotle, Marcus Aurelius, and Confucius so their chats produce answers
- make the chat UI friendlier by enlarging the conversation viewport and correcting persona image references
- improve chat error handling to surface API failures instead of defaulting to empty replies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8a543868c832f9560cb760c615573